### PR TITLE
zeal2gif

### DIFF
--- a/tools/zeal2gif/.gitignore
+++ b/tools/zeal2gif/.gitignore
@@ -1,0 +1,3 @@
+/assets
+/output
+*.zip

--- a/tools/zeal2gif/README.md
+++ b/tools/zeal2gif/README.md
@@ -1,0 +1,8 @@
+
+## Requirements:
+
+Install Pillow
+
+```sh
+pip install pillow
+```

--- a/tools/zeal2gif/gif2zeal.py
+++ b/tools/zeal2gif/gif2zeal.py
@@ -41,9 +41,9 @@ def getPalette(gif):
     g = palette[x+1]
     b = palette[x+2]
     color = reduce(lambda acc, x: (acc << 8) + x, [r,g,b])
-    print("rgb   ", str(r).rjust(3), str(g).rjust(3), str(b).rjust(3), "#{:06x}".format(color), end=" | ")
+    # print("rgb   ", str(r).rjust(3), str(g).rjust(3), str(b).rjust(3), "#{:06x}".format(color), end=" | ")
     color = RGBtoRGB565(r,g,b)
-    print("rgb565", "#{:06x}".format(color), str(color).rjust(5))
+    # print("rgb565", "#{:06x}".format(color), str(color).rjust(5))
 
     lo = color & 0xFF
     hi = (color >> 8) & 0xFF
@@ -57,13 +57,13 @@ def getPalette(gif):
 def convert(args):
   gif = Image.open(args.input)
   palette = getPalette(gif)
-  print("palette", palette)
+  # print("palette", palette)
 
   tiles = []
   tiles_per_row = int(gif.width / tile_width)
   rows = int(gif.height / tile_height)
 
-  print("tiles", tiles_per_row, rows, tiles_per_row * rows)
+  print("columns", tiles_per_row, "rows", rows, "tiles", tiles_per_row * rows)
 
   for x in range(0, tiles_per_row):
     for y in range(0, rows):
@@ -90,8 +90,8 @@ def main():
   if paletteFileName == None:
     paletteFileName = Path(args.input).with_suffix(".ztp")
 
-  print("tileset", tilesetFileName, tileset)
-  print("palette", paletteFileName, palette)
+  print("tileset", tilesetFileName) #, tileset)
+  print("palette", paletteFileName) #, palette)
 
   # tilesetFile = bytearray(tileset)
   # paletteFile = bytearray(palette)

--- a/tools/zeal2gif/gif2zeal.py
+++ b/tools/zeal2gif/gif2zeal.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import math
+from functools import reduce
+from PIL import Image
+import argparse
+from pathlib import Path
+
+
+parser = argparse.ArgumentParser("gif2zeal")
+parser.add_argument("-i", "--input", help="Input GIF Filename", required=True)
+parser.add_argument("-t","--tileset", help="Zeal Tileset (ZTS)")
+parser.add_argument("-p", "--palette", help="Zeal Palette (ZTP)")
+parser.add_argument("-b", "--bpp", help="Bits Per Pixel", type=int, default=8, choices=[1,4,8])
+parser.add_argument("-c", "--compressed", help="Compress with RLE", action="store_true")
+
+tile_width = 16
+tile_height = 16
+
+def RGBtoRGB565(r,g,b):
+  red = (r >> 3) & 0x1F
+  green = (g >> 2) & 0x3F
+  blue = (b >> 3) & 0x1F
+  return (red << 11) | (green << 5) | blue
+
+def getPalette(gif):
+  if not gif.mode == "P":
+    print("Invalid Mode, expected P and got ", gif.mode)
+    exit(2)
+  palette = gif.getpalette() # rawmode="BGR;16")
+  if palette == None:
+    print("invalid GIF palette")
+    exit(2)
+
+  result = []
+
+  for x in range(0, len(palette), 3):
+    # print("x", x)
+    # print("x", x, end="   ")
+    r = palette[x]
+    g = palette[x+1]
+    b = palette[x+2]
+    color = reduce(lambda acc, x: (acc << 8) + x, [r,g,b])
+    print("rgb   ", str(r).rjust(3), str(g).rjust(3), str(b).rjust(3), "#{:06x}".format(color), end=" | ")
+    color = RGBtoRGB565(r,g,b)
+    print("rgb565", "#{:06x}".format(color), str(color).rjust(5))
+
+    lo = color & 0xFF
+    hi = (color >> 8) & 0xFF
+
+    result.append(lo)
+    result.append(hi)
+    # print("[{}]".format(", ".join(hex(x) for x in palette)))
+  return result
+
+
+def convert(args):
+  gif = Image.open(args.input)
+  palette = getPalette(gif)
+  print("palette", palette)
+
+  tiles = []
+  tiles_per_row = int(gif.width / tile_width)
+  rows = int(gif.height / tile_height)
+
+  print("tiles", tiles_per_row, rows, tiles_per_row * rows)
+
+  for x in range(0, tiles_per_row):
+    for y in range(0, rows):
+      # print("tile", x, y)
+      ox = (x * tile_width)
+      oy = (y * tile_height)
+      tile = gif.crop((ox, oy, ox + tile_width, oy + tile_height))
+      # print("crop", ox, oy, ox + tile_width, oy + tile_height)
+      pixels = list(tile.getdata())
+      tiles = tiles + pixels
+      # print("pixels", pixels)
+
+  return (tiles, palette)
+
+def main():
+  args = parser.parse_args()
+  print("args", args)
+  tileset, palette = convert(args)
+
+  tilesetFileName = args.tileset
+  if tilesetFileName == None:
+    tilesetFileName = Path(args.input).with_suffix(".zts")
+  paletteFileName = args.palette
+  if paletteFileName == None:
+    paletteFileName = Path(args.input).with_suffix(".ztp")
+
+  print("tileset", tilesetFileName, tileset)
+  print("palette", paletteFileName, palette)
+
+  # tilesetFile = bytearray(tileset)
+  # paletteFile = bytearray(palette)
+
+  with open(tilesetFileName, "wb") as file:
+    file.write(bytearray(tileset))
+
+  with open(paletteFileName, "wb") as file:
+    file.write(bytearray(palette))
+
+  # output.save(args.input, "GIF")
+  # if(args.show):
+  #   output.show()
+
+if __name__ == "__main__":
+  main()

--- a/tools/zeal2gif/zeal2gif.py
+++ b/tools/zeal2gif/zeal2gif.py
@@ -14,19 +14,18 @@ parser.add_argument("-b", "--bpp", help="Bits Per Pixel", type=int, default=8, c
 parser.add_argument("-c", "--compressed", help="Decompress RLE", action="store_true")
 parser.add_argument("-s", "--show", help="Open in Viewer", action="store_true")
 
-tiles = []
 tile_width = 16
 tile_height = 16
-tiles_per_sheet = 16
+tiles_per_row = 16
 
 def get_tilesheet_size(tiles):
   width = 1
   height = 1
   count = len(tiles)
   # max 16 tiles across
-  if count > tiles_per_sheet:
-    width = tiles_per_sheet
-    height = math.ceil(len(tiles) / tiles_per_sheet)
+  if count > tiles_per_row:
+    width = tiles_per_row
+    height = math.ceil(len(tiles) / tiles_per_row)
   else:
     width = count
     height = 1

--- a/tools/zeal2gif/zeal2gif.py
+++ b/tools/zeal2gif/zeal2gif.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+import math
+from PIL import Image
+import argparse
+from pathlib import Path
+
+
+parser = argparse.ArgumentParser("zeal2gif")
+parser.add_argument("-t","--tileset", help="Zeal Tileset (ZTS)", required=True)
+parser.add_argument("-p", "--palette", help="Zeal Palette (ZTP)", required=True)
+parser.add_argument("-o", "--output", help="Output GIF Filename")
+parser.add_argument("-b", "--bpp", help="Bits Per Pixel", type=int, default=8, choices=[1,4,8])
+parser.add_argument("-c", "--compressed", help="Decompress RLE", action="store_true")
+parser.add_argument("-s", "--show", help="Open in Viewer", action="store_true")
+
+tiles = []
+tile_width = 16
+tile_height = 16
+tiles_per_sheet = 16
+
+def get_tilesheet_size(tiles):
+  width = 1
+  height = 1
+  count = len(tiles)
+  # max 16 tiles across
+  if count > tiles_per_sheet:
+    width = tiles_per_sheet
+    height = math.ceil(len(tiles) / tiles_per_sheet)
+  else:
+    width = count
+    height = 1
+
+  print("width", width, "height", height)
+  return (width * tile_width,height*tile_height)
+
+def RGB565toRGB(rgb565, palette):
+  # print("palette", rgb565)
+  lo = palette[rgb565 * 2]
+  hi = palette[rgb565 * 2 + 1]
+  # print("  color", hi, lo)
+  return (hi,lo)
+
+def getPalette(paletteFile):
+  pf = open(paletteFile, "rb")
+  pb = pf.read()
+  palette = []
+  for b in pb:
+    palette.append(b)
+  return palette
+
+def makeSprite(pixels):
+  # print("pixels", pixels)
+  image = Image.frombytes(
+    "RGB", # mode
+    (tile_width,tile_height), # size
+    pixels, # data
+    "raw", # decoder name
+    "BGR;16",
+    0, 1
+    )
+  return image
+
+def getSpritePixels(bpp, tile, palette):
+  sprites = []
+
+  if bpp == 1:
+    # one bit per pixel
+    for pixel in tile:
+      pixels = bytearray()
+      for b in range(8):
+        p = (b >> 1) & 1
+        (hi,lo) = RGB565toRGB(p, palette)
+        pixels.append(lo)
+        pixels.append(hi)
+      sprites.append(pixels)
+
+  elif bpp <= 4:
+    # one nibble per pixel
+    pixels = bytearray()
+    for pixel in tile:
+      p1,p2 = pixel >> 4, pixel & 0x0F
+
+      (hi,lo) = RGB565toRGB(p1, palette)
+      pixels.append(lo)
+      pixels.append(hi)
+
+      (hi,lo) = RGB565toRGB(p2, palette)
+      pixels.append(lo)
+      pixels.append(hi)
+    sprites.append(pixels)
+
+  else:
+    # one byte per pixel
+    pixels = bytearray()
+    for pixel in tile:
+      (hi,lo) = RGB565toRGB(pixel, palette)
+      pixels.append(lo)
+      pixels.append(hi)
+    sprites.append(pixels)
+
+  return sprites
+
+
+def convert(args):
+  palette = getPalette(args.palette)
+
+  f = open(args.tileset, mode="rb")
+  tiles = []
+  image_count = 0
+
+  tilesize_bpp = 0
+  if args.bpp == 1:
+    tilesize_bpp = 32
+  elif args.bpp <= 4:
+    tilesize_bpp = 128
+  else:
+    tilesize_bpp = tile_width * tile_height
+
+  tile = f.read(tilesize_bpp)
+
+  while tile:
+    print("tile len", len(tile), tilesize_bpp)
+    if len(tile) < tilesize_bpp:
+      break
+
+    images = []
+    for pixels in getSpritePixels(args.bpp, tile, palette):
+      images.append(makeSprite(pixels))
+
+    print("images", len(images))
+    for image in images:
+      tiles.append(image)
+      image_count += 1
+
+    tile = f.read(tilesize_bpp)
+
+  f.close()
+
+  tilesheet_size = get_tilesheet_size(tiles)
+  spritesheet = Image.new(mode="RGB", size=tilesheet_size)
+
+  sprites_x = int(tilesheet_size[0]/tile_width)
+  sprites_y = int(tilesheet_size[1]/tile_height)
+  print("sprites_x", sprites_x, "sprites_y", sprites_y, "tiles", len(tiles))
+  for y in range(0, sprites_y):
+    for x in range(0,sprites_x):
+      index = (y*sprites_x) + x
+      if 0 <= index < len(tiles):
+        print("sprite index", index)
+        tile = tiles[index]
+        spritesheet.paste(tile, (x * tile_width,y*tile_height))
+
+  print("sprite count", image_count)
+  return spritesheet
+
+def main():
+  args = parser.parse_args()
+  print("args", args)
+  output = convert(args)
+
+  outputFile = args.output
+  if outputFile == None:
+    outputFile = Path(args.tileset).with_suffix(".gif")
+  print("output", outputFile)
+  output.save(outputFile, "GIF")
+  if(args.show):
+    output.show()
+
+if __name__ == "__main__":
+  main()

--- a/tools/zeal2gif/zeal2gif.py
+++ b/tools/zeal2gif/zeal2gif.py
@@ -30,7 +30,7 @@ def get_tilesheet_size(tiles):
     width = count
     height = 1
 
-  print("width", width, "height", height)
+  # print("width", width, "height", height)
   return (width * tile_width,height*tile_height)
 
 def RGB565toRGB(rgb565, palette):
@@ -119,7 +119,7 @@ def convert(args):
   tile = f.read(tilesize_bpp)
 
   while tile:
-    print("tile len", len(tile), tilesize_bpp)
+    # print("tile len", len(tile), tilesize_bpp)
     if len(tile) < tilesize_bpp:
       break
 
@@ -127,7 +127,7 @@ def convert(args):
     for pixels in getSpritePixels(args.bpp, tile, palette):
       images.append(makeSprite(pixels))
 
-    print("images", len(images))
+    # print("images", len(images))
     for image in images:
       tiles.append(image)
       image_count += 1
@@ -141,16 +141,15 @@ def convert(args):
 
   sprites_x = int(tilesheet_size[0]/tile_width)
   sprites_y = int(tilesheet_size[1]/tile_height)
-  print("sprites_x", sprites_x, "sprites_y", sprites_y, "tiles", len(tiles))
   for y in range(0, sprites_y):
     for x in range(0,sprites_x):
       index = (y*sprites_x) + x
       if 0 <= index < len(tiles):
-        print("sprite index", index)
+        # print("sprite index", index)
         tile = tiles[index]
         spritesheet.paste(tile, (x * tile_width,y*tile_height))
 
-  print("sprite count", image_count)
+  print("columns", sprites_x, "rows", sprites_y, "tiles", image_count)
   return spritesheet
 
 def main():


### PR DESCRIPTION
Tool to convert GIF's to Zeal Tileset and Zeal Palette files, also includes zeal2gif which converts ZTS/ZTP files back to GIF.


Example of gif2zeal
```shell
> ./gif2zeal.py -i assets/tank.gif -t output/tank.zts -p output/tank.ztp
args Namespace(input='assets/tank.gif', tileset='output/tank.zts', palette='output/tank.ztp', bpp=8, compressed=False)
columns 2 rows 1 tiles 2
tileset output/tank.zts
palette output/tank.ztp
```

Example of zeal2gif
```shell
 > ./zeal2gif.py -t assets/letters.zts -p assets/letters.ztp -o letters.gif -b 4
args Namespace(tileset='assets/letters.zts', palette='assets/letters.ztp', output='letters.gif', bpp=4, compressed=False, show=False)
columns 16 rows 2 tiles 26
output letters.gif
```