### PR TITLE
gif2zeal/zeal2gif RLE compression, tiled2zeal fix

### DIFF
--- a/tools/tiled2zeal/tiled2zeal.py
+++ b/tools/tiled2zeal/tiled2zeal.py
@@ -19,7 +19,7 @@ def convert(args):
     return None
 
   # tiled indexes are 1 based, so we subtract 1 to make it 0 based
-  tiles = [int(i) - 1 for i in data.text.replace("\n", "").split(",")]
+  tiles = [255 if int(i) < 1 else int(i) - 1 for i in data.text.replace("\n", "").split(",")]
   return bytes(tiles)
 
 def main():


### PR DESCRIPTION
* add RLE Compression to gif2zeal/zeal2gif as described in [tools/gimp-extension/README.md]
* add "wrap around" to tiled2zeal, since Tiled stores "empty" tiles as index 0 (if Tiled has no tile, it sets the tile index to 255 ... which is likely "empty")