### PR TITLE
FEATURE: gif2zeal filename flags, fixed 1bpp mode

### DIFF
--- a/tools/zeal2gif/README.md
+++ b/tools/zeal2gif/README.md
@@ -1,8 +1,46 @@
 
+## Filename Flags
+
+Filename flags allow you to provide gif2zeal arguments in the filename of your asset.
+
+This is useful when you have multiple assets, and want to use different settings for
+each one while still taking advantage of the ZDE Makefile to auto-export Aseprite/GIF
+files to ZTS/ZTP.
+
+Filename flags are provided by adding a trailing `__` (double underscore) to the end
+of your filename, then providing the flags as follows.
+
+```text
+Flag  Argument
+----  --------
+Bn    -b N
+Cxx   -c N
+Pxx   -c N
+Sxx   -s N
+Z     -z
+```
+
+Where `n` is a number, and `xx` is a hex number.  So `S80` will strip 128 tiles, and `B4` will be `-b 4` for 16-color mode
+
+### Example of Filename flags
+
+```text
+grid__B1S03.gif
+sphere__B8C12S00Z.gif
+```
+
+This produces the equivalent of
+
+```python
+args Namespace(input='assets/grid__B1S03.gif', tileset=PosixPath('assets/grid.zts'), palette=PosixPath('assets/grid.ztp'), bpp=1, compress=False, colors=256, strip=3)
+
+args Namespace(input='assets/sphere__B8C12S00Z.gif', tileset=PosixPath('assets/sphere.zts'), palette=PosixPath('assets/sphere.ztp'), bpp=8, compress=True, colors=18, strip=0)
+```
+
 ## Requirements:
 
 Install Pillow
 
-```sh
+```shell
 pip install pillow
 ```

--- a/tools/zeal2gif/zeal2gif.py
+++ b/tools/zeal2gif/zeal2gif.py
@@ -60,9 +60,13 @@ def makeSprite(pixels, palette: list):
   image.putpalette(palette, rawmode="RGB")
   for y in range(0, tile_height):
     for x in range(0, tile_width):
+      index = (y * tile_height) + x
+      # print("tile height", tile_height, "y", y, "x", x, "index", index, "len", len(pixels))
+      if(index >= len(pixels)):
+        break
       image.putpixel(
         (x,y), # xy
-        pixels[(y * tile_height) + x] # value
+        pixels[index] # value
       )
   return image
 
@@ -71,18 +75,18 @@ def getSpritePixels(bpp, tile):
 
   if bpp == 1:
     # one bit per pixel
-    for pixel in tile:
-      pixels = bytearray()
-      for b in range(8):
-        p = (b >> 1) & 1
+    pixels = bytearray()
+    for byte in tile:
+      for bit in reversed(range(8)):
+        p = ((byte >> bit) & 1)
         pixels.append(p)
-      sprites.append(pixels)
+    sprites.append(pixels)
 
   elif bpp <= 4:
     # one nibble per pixel
     pixels = bytearray()
-    for pixel in tile:
-      p1,p2 = (pixel >> 4) & 0x0F, pixel & 0x0F
+    for byte in tile:
+      p1,p2 = (byte >> 4) & 0x0F, byte & 0x0F
       pixels.append(p1)
       pixels.append(p2)
     sprites.append(pixels)


### PR DESCRIPTION
* added filename flag support to gif2zeal
* fixed 1bpp mode for gif2zeal/zeal2gif
* changed `--compress` short flag to `-z`
* added `--colors=N/-c N` to limit the generated palette file to N
* if 1bpp or 4bpp, palette max colors is limited to 2 or 16

Example of Filename flags

```
grid__B1S03.gif
sphere__B8C12S00Z.gif
```

```
Bn  = -b N
Cxx = -c N
Pxx = -c N
Sxx = -s N
Z   = -z
```

Where `n` is a number, and `xx` is a hex number.  So `S80` will strip 128 tiles, and `B4` will be `-b 4` for 16-color mode