### PR TITLE
2zeal updates

### DIFF
--- a/tools/tiled2zeal/tiled2zeal.py
+++ b/tools/tiled2zeal/tiled2zeal.py
@@ -1,51 +1,168 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
-parser = argparse.ArgumentParser("gif2zeal")
-parser.add_argument("-i", "--input", help="Input GIF Filename", required=True)
-parser.add_argument("-m", "--tilemap", help="Zeal Tilemap (ZTM)")
+class DimensionAction(argparse.Action):
+  def __init__(self, option_strings, dest, nargs=None, **kwargs):
+    if nargs is not None:
+      raise ValueError("nargs not allowed")
+    super().__init__(option_strings, dest, **kwargs)
+  def __call__(self, parser, namespace, values, option_string=None):
+    raw = values.split("x")
+    dimension = {
+      "width": int(raw[0]),
+      "height": int(raw[1]),
+    }
+    setattr(namespace, self.dest, dimension)
 
-def convert(args):
-  maps = []
-  tree = ET.parse(args.input)
-  root = tree.getroot()
 
-  layers = root.findall("layer")
+parser = argparse.ArgumentParser("tiled2zeal")
+parser.add_argument("-i", "--input", help="Input TMX Filename", required=True)
+parser.add_argument("-o", "--output", help="Output path, can be just a path")
+parser.add_argument("-l", "--layer", help="Layer to use", type=int)
+parser.add_argument("-s", "--size", help="Screen Width/Height, for larger world maps", action=DimensionAction, default=None)
+parser.add_argument("-v", "--verbose", help="Verbose output", action='store_true')
+parser.add_argument("-d", "--debug", help="Debug output", action='store_true')
+
+root = None
+meta = None
+
+def create_dir(file_path):
+  if "." in os.path.basename(file_path):
+      directory = os.path.dirname(file_path)
+  else:
+      directory = file_path
+  if directory and not os.path.exists(directory):
+      os.makedirs(directory, exist_ok=True)
+
+def process_paths(input_path, output_path):
+  # Extract input directory and filename
+  input_dir = os.path.dirname(input_path)
+  input_filename = os.path.basename(input_path)
+
+  # Check if output path has an extension (meaning it's a file) or is a directory
+  output_has_extension = "." in os.path.basename(output_path)
+
+  if output_has_extension:
+      output_dir = os.path.dirname(output_path)
+      output_filename = os.path.basename(output_path)
+  else:
+      output_dir = output_path  # Assume it's a directory
+      output_filename = os.path.splitext(input_filename)[0] + ".ztm"
+
+  # Construct full output path
+  full_output_path = os.path.join(output_dir, output_filename)
+
+  return output_dir, output_filename, full_output_path
+
+def get_layers(layer):
+  if layer:
+    layers = root.findall("layer[@id='" + str(layer) + "']")
+  else:
+    layers = root.findall("layer")
+
+  results = []
   for layer in layers:
     data = layer.find("data")
-
     if not data.attrib["encoding"] == 'csv':
       print("Invalid Data Encoding, expected CSV and got ", data.attrib["encoding"])
       return None
 
     # tiled indexes are 1 based, so we subtract 1 to make it 0 based
     tiles = [255 if int(i) < 1 else int(i) - 1 for i in data.text.replace("\n", "").split(",")]
-    maps.append(bytes(tiles))
+    results.append(tiles)
+
+  return results
+
+def get_screens(args, layer):
+  screens = []
+  if args.size:
+    mw = int(meta["width"])       # map width
+    mh = int(meta["height"])      # map height
+    sw = int(args.size["width"])  # screen width
+    sh = int(args.size["height"]) # screen height
+    sx = mw//sw                   # horizontal screens
+    sy = mh//sh                   # vertical screens
+
+    for i in range(sy): # vertical screens
+      for j in range(sx): # horizontal screens
+        world_offset = ((mw * i) * sh) + (sw * j)
+        screen = []
+        for y in range(sh): # screen height
+          line = []
+          for x in range(sw): # screen width
+            offset = world_offset + (mw * y) + x
+            tile = layer[offset]
+            if args.debug:
+              print("offset", {
+                "map_y": i,
+                "map_x": j,
+                "scr_y": y,
+                "scr_x": x,
+                "offset": offset,
+                "tile": tile
+              })
+            line.append(tile)
+          screen = screen + line
+        if args.debug:
+          print("screen", len(screen), sh, sw)
+        screens.append(bytes(screen))
+  else:
+    screens.append(bytes(layer))
+
+  return screens
+
+def convert(args):
+  maps = []
+  layers = get_layers(args.layer)
+  for layer in layers:
+    screens = get_screens(args, layer)
+    for screen in screens:
+      maps.append(bytes(screen))
   return maps
 
 def main():
+  global root, meta
   args = parser.parse_args()
-  print("args", args)
+  tree = ET.parse(args.input)
+  root = tree.getroot()
+  meta = root.attrib
+
+  if args.verbose:
+    print("args", args)
+    print("root", root)
+    print("meta", meta)
+
   maps = convert(args)
+
   if not maps or len(maps) < 1:
     print("Failed to convert")
     return
 
+  outputDir, outputFilename, outputPath = process_paths(args.input, args.output)
+  if args.debug:
+    print("outputDir", outputDir)
+    print("outputFilename", outputFilename)
+    print("outputPath", outputPath)
+
+  create_dir(outputDir)
+
   for idx, tilemap in enumerate(maps):
-    if args.tilemap:
-      p = Path(args.tilemap)
+    if outputPath:
+      p = Path(outputPath)
       index = ""
       if len(maps) > 1:
-        index = f"-{str(idx)}"
+        index = f"{str(idx).zfill(4)}"
       tilemapFileName = p.parent / f"{p.stem}{index}{p.suffix}"
 
     if tilemapFileName == None:
-      tilemapFileName = Path(args.input + "-" + str(idx)).with_suffix(".ztm")
+      tilemapFileName = Path(args.input + str(idx).zfill(4)).with_suffix(".ztm")
 
-    print("tilemap", tilemapFileName) #, tilemap)
+    if args.verbose:
+      print("tilemap", tilemapFileName)
     with open(tilemapFileName, "wb") as file:
       file.write(tilemap)
 

--- a/tools/zeal2gif/zeal2gif.py
+++ b/tools/zeal2gif/zeal2gif.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import math
+import os
 import io
 from PIL import Image
 import argparse
@@ -12,12 +13,22 @@ parser.add_argument("-t","--tileset", help="Zeal Tileset (ZTS)", required=True)
 parser.add_argument("-p", "--palette", help="Zeal Palette (ZTP)", required=True)
 parser.add_argument("-o", "--output", help="Output GIF Filename")
 parser.add_argument("-b", "--bpp", help="Bits Per Pixel", type=int, default=8, choices=[1,4,8])
-parser.add_argument("-c", "--compressed", help="Decompress RLE", action="store_true")
+parser.add_argument("-z", "--compressed", help="Decompress RLE", action="store_true")
 parser.add_argument("-s", "--show", help="Open in Viewer", action="store_true")
+parser.add_argument("-v", "--verbose", help="Verbose output", action='store_true')
+parser.add_argument("-d", "--debug", help="Debug output", action='store_true')
 
 tile_width = 16
 tile_height = 16
 tiles_per_row = 16
+
+def create_dir(file_path):
+  if "." in os.path.basename(file_path):
+      directory = os.path.dirname(file_path)
+  else:
+      directory = file_path
+  if directory and not os.path.exists(directory):
+      os.makedirs(directory, exist_ok=True)
 
 def get_tilesheet_size(tiles):
   width = 1
@@ -170,18 +181,25 @@ def convert(args):
         tile = tiles[index]
         spritesheet.paste(tile, (x * tile_width,y*tile_height))
 
-  print("columns", sprites_x, "rows", sprites_y, "tiles", image_count)
+  if args.debug:
+    print("columns", sprites_x, "rows", sprites_y, "tiles", image_count)
   return spritesheet
 
 def main():
   args = parser.parse_args()
-  print("args", args)
+  if args.verbose:
+    print("args", args)
   output = convert(args)
 
   outputFile = args.output
   if outputFile == None:
     outputFile = Path(args.tileset).with_suffix(".gif")
-  print("output", outputFile)
+
+  create_dir(outputFile)
+
+  if args.verbose:
+    print("output", outputFile)
+
   output.save(
     outputFile,
     format="GIF",


### PR DESCRIPTION
* auto-generate output dir if not exist
* tiled2zeal, gif2zeal now support --output which will allow setting the output destination folder
* switch `-c` to `-z` for zeal2gif to match gif2zeal
* add --verbose and --debug flags, to reduce console flood
* tiled2zeal now supports --size for exporting larger world maps into smaller screen maps
* tiled2zeal now supports limiting to a specific layer