### PR TITLE
tiled2zeal - process_paths bug fix

### DIFF
--- a/tools/tiled2zeal/tiled2zeal.py
+++ b/tools/tiled2zeal/tiled2zeal.py
@@ -45,7 +45,7 @@ def process_paths(input_path, output_path):
   input_filename = os.path.basename(input_path)
 
   if not output_path:
-    output_path = input_path
+    output_path = Path(input_path).with_suffix(".ztm")
 
   # Check if output path has an extension (meaning it's a file) or is a directory
   output_has_extension = "." in os.path.basename(output_path)


### PR DESCRIPTION
* fix bug in tiled2zeal process_paths that overwrites the input file when not output is specified